### PR TITLE
make field nullable.

### DIFF
--- a/airqo_monitor/migrations/0003_auto_20181024_1033.py
+++ b/airqo_monitor/migrations/0003_auto_20181024_1033.py
@@ -46,7 +46,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='incident',
             name='channel',
-            field=models.ForeignKey(default=1, on_delete=django.db.models.deletion.DO_NOTHING, to='airqo_monitor.Channel'),
-            preserve_default=False,
+            field=models.ForeignKey(on_delete=django.db.models.deletion.DO_NOTHING, to='airqo_monitor.Channel', null=True),
         ),
     ]


### PR DESCRIPTION
we messed up the migrations such that they couldnt go through, manually editing this field to no longer have a default and to not be required
