### PR TITLE
Format time

### DIFF
--- a/airqo_monitor/serializers.py
+++ b/airqo_monitor/serializers.py
@@ -1,5 +1,3 @@
-import pytz
-
 from rest_framework import serializers
 
 from airqo_monitor.models import (

--- a/airqo_monitor/serializers.py
+++ b/airqo_monitor/serializers.py
@@ -1,3 +1,5 @@
+import pytz
+
 from rest_framework import serializers
 
 from airqo_monitor.models import (
@@ -68,7 +70,7 @@ class ChannelNoteSerializer(serializers.ModelSerializer):
 
 class ChannelHistorySerializer(serializers.Serializer):
     object_type = serializers.SerializerMethodField()
-    created_at = serializers.DateTimeField()
+    created_at = serializers.SerializerMethodField()
     note = serializers.SerializerMethodField()
     author = serializers.SerializerMethodField()
     resolved_at = serializers.SerializerMethodField()
@@ -93,6 +95,9 @@ class ChannelHistorySerializer(serializers.Serializer):
             return obj.author
         if object_type == 'incident':
             return None
+
+    def get_created_at(self, obj):
+        return obj.created_at
 
     def get_resolved_at(self, obj):
         object_type = self.get_object_type(obj)

--- a/airqo_monitor/templates/channel_detail.html
+++ b/airqo_monitor/templates/channel_detail.html
@@ -50,6 +50,8 @@
 
     <div class="wrapper">
         <strong>Channel History</strong>
+        <br/>
+        All times in utc
         {% for point in history %}
           <br/><br/>
           {% if point.object_type == 'channel_note' %}


### PR DESCRIPTION
There seems to be some sort of built in time formatting in the django serializers for datetimes, lets use it for both timestamps so that the dates are human readable. for some reason I can't get converting to local time to work here, I will keep working on that but this at least makes them pretty in the meantime and adds a note that times are in UTC until we are able to make them local time.

<img width="426" alt="screen shot 2018-11-01 at 9 39 14 pm" src="https://user-images.githubusercontent.com/2432011/47872019-9a112480-de1e-11e8-8395-18f24941972b.png">
