### PR TITLE
add filter for channel id.

### DIFF
--- a/airqo_monitor/management/commands/utils.py
+++ b/airqo_monitor/management/commands/utils.py
@@ -6,6 +6,7 @@ from airqo_monitor.models import (
     GlobalVariable,
     MalfunctionReason,
 )
+from airqo_monitor.utils import update_last_channel_update_time
 
 def create_basic_test_data():
     # ChannelType
@@ -18,6 +19,7 @@ def create_basic_test_data():
 
     # Malfunction detection variables
     GlobalVariable.objects.get_or_create(key='LAST_CHANNEL_UPDATE_TIME')
+    update_last_channel_update_time()
 
     low_battery_cutoff, _ = GlobalVariable.objects.get_or_create(key='LOW_BATTERY_CUTOFF')
     low_battery_cutoff.value = '0.3'

--- a/airqo_monitor/tests/test_format_data.py
+++ b/airqo_monitor/tests/test_format_data.py
@@ -17,6 +17,7 @@ from airqo_monitor.external.thingspeak import (
 from airqo_monitor.format_data import (
     get_and_format_data_for_all_channels,
     get_and_format_data_for_channel,
+    get_and_format_data_for_channels,
 )
 
 
@@ -146,6 +147,63 @@ class TestFormatData(TestCase):
         get_and_format_data_for_channel_mocker.return_value = [entry]
 
         channel_info = get_and_format_data_for_all_channels()
+        assert len(channel_info) == 2
+
+        channel1 = Channel.objects.get(name='channel1')
+        channel2 = Channel.objects.get(name='channel2')
+
+        assert channel1.channel_id == 9999
+        assert channel1.channel_type is not None
+
+        assert channel2.channel_id == 8888
+        assert channel2.channel_type is not None
+
+        assert len(channel_info[9999]['data']) == 1
+        assert channel_info[9999]['data'][0].get('entry_id') == 1
+        assert channel_info[9999]['data'][0].get('latitude') == '1'
+        assert channel_info[9999]['data'][0].get('longitude') == '1'
+
+        assert len(channel_info[8888]['data']) == 1
+        assert channel_info[8888]['data'][0].get('entry_id') == 1
+        assert channel_info[8888]['data'][0].get('latitude') == '1'
+        assert channel_info[8888]['data'][0].get('longitude') == '1'
+
+    @mock.patch('airqo_monitor.format_data.get_and_format_data_for_channel')
+    @mock.patch('airqo_monitor.format_data.get_all_channels_by_type')
+    def test_get_and_format_heatmap_data_for_channels(self, get_all_channels_mocker, get_and_format_data_for_channel_mocker):
+        get_all_channels_mocker.return_value = [
+            dict(name='channel1', id=9999),
+            dict(name='channel2', id=8888),
+        ]
+
+        entry = {'entry_id': 1, 'latitude': '1', 'longitude': '1'}
+        get_and_format_data_for_channel_mocker.return_value = [entry]
+
+        channel_info = get_and_format_data_for_channels(channel_ids=['9999'])
+        assert len(channel_info) == 1
+
+        channel1 = Channel.objects.get(name='channel1')
+        assert channel1.channel_id == 9999
+        assert channel1.channel_type is not None
+
+        assert len(channel_info[9999]['data']) == 1
+        assert channel_info[9999]['data'][0].get('entry_id') == 1
+        assert channel_info[9999]['data'][0].get('latitude') == '1'
+        assert channel_info[9999]['data'][0].get('longitude') == '1'
+
+        channel_info = get_and_format_data_for_channels(channel_ids=['8888'])
+        assert len(channel_info) == 1
+
+        channel2 = Channel.objects.get(name='channel2')
+        assert channel2.channel_id == 8888
+        assert channel2.channel_type is not None
+
+        assert len(channel_info[8888]['data']) == 1
+        assert channel_info[8888]['data'][0].get('entry_id') == 1
+        assert channel_info[8888]['data'][0].get('latitude') == '1'
+        assert channel_info[8888]['data'][0].get('longitude') == '1'
+
+        channel_info = get_and_format_data_for_channels(channel_ids=['8888', '9999'])
         assert len(channel_info) == 2
 
         channel1 = Channel.objects.get(name='channel1')

--- a/airqo_monitor/views.py
+++ b/airqo_monitor/views.py
@@ -15,7 +15,10 @@ from airqo_monitor.models import Incident
 from airqo_monitor.malfunction_detection.get_malfunctions import (
     get_all_channel_malfunctions
 )
-from airqo_monitor.format_data import get_and_format_heatmap_data_for_all_channels
+from airqo_monitor.format_data import (
+    get_and_format_heatmap_data_for_all_channels,
+    get_and_format_heatmap_data_for_channels,
+)
 from airqo_monitor.models import (
     Channel,
     ChannelNote,
@@ -136,5 +139,15 @@ def update_incidents(request):
 def heatmap(request):
     start_time = datetime.utcnow() - timedelta(days=1)
     heatmap_data = get_and_format_heatmap_data_for_all_channels(start_time=start_time)
+    heatmap_json = simplejson.dumps(heatmap_data)
+    return render(request, "heatmap.html", context={"geojson_points": mark_safe(heatmap_data)})
+
+def heatmap_with_filter(request, channel_ids):
+    """
+    Takes in comma separated list of thingspeak channel_ids and filters heatmap data to
+    only show data for those channels.
+    """
+    start_time = datetime.utcnow() - timedelta(days=1)
+    heatmap_data = get_and_format_heatmap_data_for_channels(start_time=start_time, channel_ids=channel_ids.split(','))
     heatmap_json = simplejson.dumps(heatmap_data)
     return render(request, "heatmap.html", context={"geojson_points": mark_safe(heatmap_data)})

--- a/airqo_monitor/views.py
+++ b/airqo_monitor/views.py
@@ -6,6 +6,7 @@ from django.http import Http404, HttpResponse
 from django.utils.safestring import mark_safe
 import json as simplejson
 from datetime import datetime, timedelta
+from urllib import parse
 
 from airqo_monitor.constants import (
     PYTZ_KAMPALA_STRING,
@@ -137,17 +138,29 @@ def update_incidents(request):
     return redirect('/')
 
 def heatmap(request):
-    start_time = datetime.utcnow() - timedelta(days=1)
-    heatmap_data = get_and_format_heatmap_data_for_all_channels(start_time=start_time)
-    heatmap_json = simplejson.dumps(heatmap_data)
-    return render(request, "heatmap.html", context={"geojson_points": mark_safe(heatmap_data)})
+    query_string = request.META.get('QUERY_STRING')
+    queries = parse.parse_qs(query_string)
 
-def heatmap_with_filter(request, channel_ids):
-    """
-    Takes in comma separated list of thingspeak channel_ids and filters heatmap data to
-    only show data for those channels.
-    """
-    start_time = datetime.utcnow() - timedelta(days=1)
-    heatmap_data = get_and_format_heatmap_data_for_channels(start_time=start_time, channel_ids=channel_ids.split(','))
+    start_time = None
+    end_time = None
+    channel_ids = queries.get('channel_ids', None)
+
+    start_time_str = queries.get('start_time', None)
+    if start_time_str:
+        # TODO: implement parsing the time string
+        pass
+    else:
+        start_time = datetime.utcnow() - timedelta(days=1)
+
+    end_time_str = queries.get('end_time', None)
+    if end_time_str:
+        # TODO: implement parsing the time string
+        pass
+
+    heatmap_data = get_and_format_heatmap_data_for_channels(
+        start_time=start_time,
+        end_time=end_time,
+        channel_ids=channel_ids,
+    )
     heatmap_json = simplejson.dumps(heatmap_data)
     return render(request, "heatmap.html", context={"geojson_points": mark_safe(heatmap_data)})

--- a/airqo_monitor/views.py
+++ b/airqo_monitor/views.py
@@ -143,7 +143,7 @@ def heatmap(request):
 
     start_time = None
     end_time = None
-    channel_ids = queries.get('channel_ids', None)
+    channel_ids = None
 
     start_time_str = queries.get('start_time', None)
     if start_time_str:
@@ -156,6 +156,10 @@ def heatmap(request):
     if end_time_str:
         # TODO: implement parsing the time string
         pass
+
+    channel_ids_str = queries.get('channel_ids', None)
+    if channel_ids_str:
+        channel_ids = channel_ids_str[0].split(',')
 
     heatmap_data = get_and_format_heatmap_data_for_channels(
         start_time=start_time,

--- a/gettingstarted/urls.py
+++ b/gettingstarted/urls.py
@@ -25,5 +25,5 @@ urlpatterns = [
     path("channel_types/", airqo_monitor.views.channel_types_list, name='all_channels_list'),
     path("channel_types/<str:channel_type>/", airqo_monitor.views.channel_type_channels_list, name='channels_list'),
     path("heatmap/", airqo_monitor.views.heatmap, name="heatmap"),
-    path("heatmap/<str:channel_ids>/", airqo_monitor.views.heatmap_with_filter, name="heatmap_with_filter"),
+    # path("heatmap/<str:channel_ids>/", airqo_monitor.views.heatmap_with_filter, name="heatmap_with_filter"),
 ]

--- a/gettingstarted/urls.py
+++ b/gettingstarted/urls.py
@@ -24,5 +24,6 @@ urlpatterns = [
     path("update_incidents/", airqo_monitor.views.update_incidents, name='update_incidents'),
     path("channel_types/", airqo_monitor.views.channel_types_list, name='all_channels_list'),
     path("channel_types/<str:channel_type>/", airqo_monitor.views.channel_type_channels_list, name='channels_list'),
-    path("heatmap/", airqo_monitor.views.heatmap, name="heatmap")
+    path("heatmap/", airqo_monitor.views.heatmap, name="heatmap"),
+    path("heatmap/<str:channel_ids>/", airqo_monitor.views.heatmap_with_filter, name="heatmap_with_filter"),
 ]


### PR DESCRIPTION
Add url for filtered heatmap, so you can do like http://127.0.0.1:8000/heatmap/318099,324682/ to see the heatmap for only those channels. we can also add start and end date filters to this in another PR.

This currently just works if you go directly to the URL, we should also add an interface on  http://127.0.0.1:8000/heatmap/ that automatically takes inputs and redirects accordingly

Added unit test and tested locally.